### PR TITLE
prevent input of "e" in purse popup

### DIFF
--- a/src/App/Views/Equipment/PurseAddRemoveMoney.tsx
+++ b/src/App/Views/Equipment/PurseAddRemoveMoney.tsx
@@ -202,32 +202,24 @@ export const PurseAddRemoveMoney: React.FC<PurseAddRemoveMoneyProps> = props => 
             <TextField
               label={translate (staticData) ("equipment.purse.ducats")}
               value={valueD}
-              type="number"
-              min="0"
               valid={isNaturalNumber (valueD)}
               onChange={setValueDSafe}
               />
             <TextField
               label={translate (staticData) ("equipment.purse.silverthalers")}
               value={valueS}
-              type="number"
-              min="0"
               valid={isNaturalNumber (valueS)}
               onChange={setValueSSafe}
               />
             <TextField
               label={translate (staticData) ("equipment.purse.halers")}
               value={valueH}
-              type="number"
-              min="0"
               valid={isNaturalNumber (valueH)}
               onChange={setValueHSafe}
               />
             <TextField
               label={translate (staticData) ("equipment.purse.kreutzers")}
               value={valueK}
-              type="number"
-              min="0"
               valid={isNaturalNumber (valueK)}
               onChange={setValueKSafe}
               />


### PR DESCRIPTION
Another improvement for the purse popup.
In the newest version we already prevent any input that is neither an empty string or a natural number.
Unfortunately, "e" is treated as empty string when used in a number input.
--> return to text input