### PR TITLE
Bugfix: TypeScript emit ES Modules

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "importHelpers": true,
     "jsx": "react",
     "lib": ["esnext", "dom"],
-    "module": "CommonJS",
+    "module": "ES2020",
     "moduleResolution": "node",
     "noEmitHelpers": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
TypeScript should emit ES Modules, but I changed it for #678 and forgot to change it back.