### PR TITLE
ci: restrict push/pull_request events

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,9 @@ name: Integration
 
 on:
   push:
+    branches:
+    - master
+    - develop
   pull_request:
     branches:
     - master
@@ -17,10 +20,10 @@ jobs:
       with:
         token: ${{ secrets.ACCESS_TOKEN }}
         submodules: true
-    - name: Use Node.js 12.x
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
     - name: Install Node.js dependencies
       run: npm ci
     - run: npm run re:build

--- a/package.json
+++ b/package.json
@@ -98,8 +98,8 @@
     "start": "electron .",
     "test": "jest",
     "circ": "madge -c ./src",
-    "release:main": "standard-version --dry-run --skip.commit --skip.tag",
-    "release:pre": "standard-version --prerelease=alpha --dry-run --skip.changelog"
+    "release:main": "standard-version --skip.commit --skip.tag",
+    "release:pre": "standard-version --prerelease=alpha --skip.changelog"
   },
   "repository": "github:elyukai/optolith-client",
   "husky": {


### PR DESCRIPTION
This way, push events should not be triggered if pull_requests are made towards on of the main branches.