### PR TITLE
Docs: Fix build command in package.json and Contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ Compile the source code. `js:` is for TypeScript/Webpack, `re:` for Reason/OCaml
 You have to run the Reason build first as it generates TypeScript files...
 
 ```sh
-npm run re:build
+npm run ts:build
 npm run css:build
 npm run js:build
 ```

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "stable:mac": "NODE_ENV=production node ./deploy/buildMac.js",
     "css:build": "sass --style=compressed src/Main.scss app/main.css",
     "css:watch": "sass --watch --style=compressed src/Main.scss app/main.css",
-    "build": "npm run re:build && npm run css:build && npm run js:build",
+    "build": "npm run ts:build && npm run css:build && npm run js:build",
     "js:build": "webpack",
     "js:watch": "webpack -w",
     "ts:build": "tsc",


### PR DESCRIPTION
Just an small think i found when working with the client the build command is wrong in package.json and Contributing.md

docs: corrected build command for ts
fix: fix build script to use ts:build and not re:build
